### PR TITLE
TX continuous heartbeat: receivers self-heal from missed packets

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,9 @@ It runs an AsyncWebServer serving a simple HTML/CSS/JS page from a filesystem, w
 
 ![TX UI](_docs/TX-UI.png)
 
-The RF24 module uses a configurable transmit power with multiple channels available, but does not avoid packet collision with other sources using the same frequency. For this reason we retransmit each command multiple times in quick succession, in the hope that 'one gets through'. It also requires a stable 3.3v supply, which at high-power transmission could exceed that available from the ESP32, so a separate buck converter is used fed from the power supply.
+The RF24 module uses a configurable transmit power with multiple channels available, but does not avoid packet collision with other sources using the same frequency. To work around this, the TX continuously rebroadcasts the current pattern at 10 Hz (a "heartbeat") so that receivers which miss any individual packet — or that come online late or reboot mid-performance — catch up to the current pattern within ~100 ms. UI mode changes are also sent immediately for zero perceptible latency. The RF24 module requires a stable 3.3v supply, which at high-power transmission could exceed that available from the ESP32, so a separate buck converter is used fed from the power supply.
+
+> **Firmware compatibility:** the heartbeat behaviour requires the matching RX firmware. When upgrading from a pre-heartbeat release, flash all TX and RX units together — a new TX paired with an old RX will visibly malfunction (the old RX clears its LEDs on every received packet and so will wipe running patterns ten times per second).
 
 ## Receiver
 

--- a/RX/src/main.cpp
+++ b/RX/src/main.cpp
@@ -166,13 +166,19 @@ void readRadio()
   { // is there a payload?
     int payload;
     radio.read(&payload, sizeof(payload)); // get incoming payload
-    ledMode = payload;
 
-    Serial.print("Radio RX data: ");
-    Serial.println(ledMode);
-
-    // clear all pixels ready for the new mode
-    FastLED.clear();
+    // Idempotent: heartbeats arrive ~10x per second carrying the current
+    // mode. Only react when the mode actually changes — otherwise we'd
+    // wipe running patterns at 10 Hz. This equality guard is also what
+    // keeps mid-strobe heartbeats from re-triggering case 98 (which
+    // restores ledMode to the prior mode after flashing).
+    if (payload != ledMode)
+    {
+      ledMode = payload;
+      Serial.print("Radio RX mode change: ");
+      Serial.println(ledMode);
+      FastLED.clear();
+    }
   }
 }
 
@@ -334,12 +340,21 @@ void loop()
     break;
 
   case 98:
-    // quick white strobe - flashes multiple times because TX resends mode 3 times :-|
-    fill_solid(leds, numLeds, CRGB::White);
-    FastLED.show();
-    FastLED.delay(30);
-    FastLED.clear();
-    ledMode = currentMode; // reinstate the previous mode
+    // 5-flash white strobe — TX now sends mode 98 as a single packet,
+    // so the RX produces all 5 flashes from one receive. Total ~300ms.
+    // Heartbeats arriving during this loop are buffered by the nRF24's
+    // 3-deep RX FIFO and are duplicates of the prior mode, so the
+    // idempotency guard in readRadio() will no-op them after the strobe.
+    for (int i = 0; i < 5; i++)
+    {
+      fill_solid(leds, numLeds, CRGB::White);
+      FastLED.show();
+      FastLED.delay(30);
+      FastLED.clear();
+      FastLED.show();
+      FastLED.delay(30);
+    }
+    ledMode = currentMode; // restore prior mode (load-bearing — otherwise loop re-enters case 98)
     break;
 
   case 99:

--- a/TX/src/main.cpp
+++ b/TX/src/main.cpp
@@ -174,8 +174,6 @@ void handleWSMessage(void *arg, uint8_t *data, size_t len)
       return;
     }
 
-    int previousMode = CurrentMode;
-
     if (newMode == AUTO_MODE)
     { // auto
       Serial.printf("AUTO mode set ON\n");
@@ -183,7 +181,7 @@ void handleWSMessage(void *arg, uint8_t *data, size_t len)
       Serial.printf("CurrentMode randomised to #%d\n", newMode);
       autoDelay.start(AUTO_TIME);
     }
-    else if (previousMode == AUTO_MODE)
+    else if (autoDelay.isRunning())
     {
       autoDelay.stop();
       Serial.printf("AUTO mode set OFF\n");

--- a/TX/src/main.cpp
+++ b/TX/src/main.cpp
@@ -42,7 +42,7 @@ DNSServer dnsServer;
 #define NRF24L01_PIN_CS 5
 RF24 radio(NRF24L01_PIN_CE, NRF24L01_PIN_CS);
 const byte address[5] = {'R', 'x', 'A', 'A', '1'};
-const byte RETRANSMITS = 5; // how many times we retransmit every message, for reliability in noisy RF environments
+const unsigned long HEARTBEAT_INTERVAL = 100; // ms — TX continuously rebroadcasts CurrentMode at this cadence so receivers self-heal from lost packets and late joiners catch up
 
 #define LED_BUILTIN 2
 
@@ -51,6 +51,7 @@ int CurrentMode = 0;
 const unsigned long AUTO_TIME = 30000; // in mS
 const int AUTO_MODE = -1;
 millisDelay autoDelay; // the delay object
+millisDelay heartbeatDelay; // ticks every HEARTBEAT_INTERVAL ms to rebroadcast CurrentMode
 
 const int autoModes[24] = {
     1, 2, 3, 4, 5, 6, 7, 8,
@@ -140,14 +141,9 @@ void notifyClients()
   Serial.printf("CurrentMode #%d broadcasted to WS\n", CurrentMode);
 }
 
-void broadcastRF()
+void sendModeRF(int mode)
 {
-  for (size_t i = 0; i < RETRANSMITS; i++)
-  {
-    radio.write(&CurrentMode, sizeof(CurrentMode), true);
-    delay(10);
-  }
-  Serial.printf("CurrentMode #%d broadcasted to RF\n", CurrentMode);
+  radio.write(&mode, sizeof(mode), true);
 }
 
 void handleWSMessage(void *arg, uint8_t *data, size_t len)
@@ -155,7 +151,6 @@ void handleWSMessage(void *arg, uint8_t *data, size_t len)
   AwsFrameInfo *info = (AwsFrameInfo *)arg;
   if (info->final && info->index == 0 && info->len == len && info->opcode == WS_TEXT)
   {
-
     const size_t size = JSON_OBJECT_SIZE(1);
     StaticJsonDocument<size> json;
     DeserializationError err = deserializeJson(json, data);
@@ -166,22 +161,29 @@ void handleWSMessage(void *arg, uint8_t *data, size_t len)
       return;
     }
 
-    int previousMode = CurrentMode;
-
     int newMode = json["mode"];
-
     Serial.printf("Received mode #%d\n", newMode);
+
+    // Mode 98 (strobe) is a one-shot transient. Send a single packet directly
+    // and do NOT update CurrentMode — the heartbeat must keep broadcasting
+    // the actual steady-state pattern, not 98.
+    if (newMode == 98)
+    {
+      sendModeRF(98);
+      Serial.println("Strobe transient sent (CurrentMode unchanged)");
+      return;
+    }
+
+    int previousMode = CurrentMode;
 
     if (newMode == AUTO_MODE)
     { // auto
       Serial.printf("AUTO mode set ON\n");
-
-      // set a random mode
       newMode = autoModes[random(24)];
       Serial.printf("CurrentMode randomised to #%d\n", newMode);
       autoDelay.start(AUTO_TIME);
     }
-    else if (CurrentMode = AUTO_MODE)
+    else if (previousMode == AUTO_MODE)
     {
       autoDelay.stop();
       Serial.printf("AUTO mode set OFF\n");
@@ -190,13 +192,10 @@ void handleWSMessage(void *arg, uint8_t *data, size_t len)
     CurrentMode = newMode;
     Serial.printf("CurrentMode set to #%d\n", CurrentMode);
 
-    broadcastRF();
-
-    if (newMode == 98)
-    { // revert mode for strobe (RX automatically revert so no need to TX)
-      CurrentMode = previousMode;
-      Serial.printf("CurrentMode reverted to #%d\n", previousMode);
-    }
+    // Edge send: zero-latency UI response. Restart the heartbeat clock so
+    // the next heartbeat lands one full interval later, not piggy-backed.
+    sendModeRF(CurrentMode);
+    heartbeatDelay.restart();
 
     notifyClients();
   }
@@ -277,6 +276,7 @@ void setup()
   }
 
   initRadio();
+  heartbeatDelay.start(HEARTBEAT_INTERVAL);
 
   if(!LittleFS.begin(true)){
     Serial.println("An Error has occurred while mounting LITTLEFS");
@@ -306,11 +306,18 @@ void loop()
     CurrentMode = autoModes[random(24)];
     Serial.printf("CurrentMode randomised to #%d\n", CurrentMode);
 
-    broadcastRF();
+    sendModeRF(CurrentMode);
+    heartbeatDelay.restart();
     notifyClients();
 
     autoDelay.repeat(); // repeat
     Serial.println("autoDelay restarted");
+  }
+
+  if (heartbeatDelay.justFinished())
+  {
+    sendModeRF(CurrentMode);
+    heartbeatDelay.repeat();
   }
 
   delay(DNS_INTERVAL);  // seems to help with stability, if you are doing other things in the loop this may not be needed

--- a/docs/superpowers/plans/2026-05-17-rf-heartbeat.md
+++ b/docs/superpowers/plans/2026-05-17-rf-heartbeat.md
@@ -102,8 +102,6 @@ void handleWSMessage(void *arg, uint8_t *data, size_t len)
       return;
     }
 
-    int previousMode = CurrentMode;
-
     if (newMode == AUTO_MODE)
     { // auto
       Serial.printf("AUTO mode set ON\n");
@@ -111,7 +109,7 @@ void handleWSMessage(void *arg, uint8_t *data, size_t len)
       Serial.printf("CurrentMode randomised to #%d\n", newMode);
       autoDelay.start(AUTO_TIME);
     }
-    else if (previousMode == AUTO_MODE)
+    else if (autoDelay.isRunning())
     {
       autoDelay.stop();
       Serial.printf("AUTO mode set OFF\n");
@@ -132,7 +130,7 @@ void handleWSMessage(void *arg, uint8_t *data, size_t len)
 
 Key things this rewrite does:
 - Short-circuits mode 98 at the top: single packet, no state change, return.
-- Fixes the `else if (CurrentMode = AUTO_MODE)` assignment bug → `else if (previousMode == AUTO_MODE)`.
+- Fixes the `else if (CurrentMode = AUTO_MODE)` assignment bug. The naive fix `previousMode == AUTO_MODE` does NOT work — `CurrentMode` never actually holds `AUTO_MODE` while AUTO is running (the AUTO branch overwrites `newMode` with a real mode value before assigning it to `CurrentMode`). Use `autoDelay.isRunning()` instead. This also lets us drop the `previousMode` local entirely.
 - Replaces `broadcastRF()` with `sendModeRF(CurrentMode); heartbeatDelay.restart();`.
 - Removes the now-unnecessary `previousMode` save/revert dance around mode 98 (mode 98 returns before touching `CurrentMode`).
 

--- a/docs/superpowers/plans/2026-05-17-rf-heartbeat.md
+++ b/docs/superpowers/plans/2026-05-17-rf-heartbeat.md
@@ -1,0 +1,411 @@
+# RF Heartbeat Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the TX's 5×-burst-on-change with a 100 ms heartbeat that continuously broadcasts the current mode, so receivers self-heal from lost packets and late joiners catch up within one interval — while preserving zero-latency response to UI mode changes.
+
+**Architecture:** TX maintains `CurrentMode` as today, but always sends one packet per heartbeat tick (10 Hz). UI mode changes call the same single-packet send immediately and reset the heartbeat clock. Mode 98 (strobe) becomes a single-packet transient that bypasses `CurrentMode` (so the heartbeat never broadcasts 98). RX becomes idempotent: it only mutates state when the received mode differs from the running one, so heartbeat duplicates are no-ops. The 5-flash strobe visual moves entirely to the RX (one packet → one 5-flash loop).
+
+**Tech Stack:** PlatformIO; Arduino-ESP32 (TX, ESP32) + Arduino-ESP8266 (RX, ESP8266); RF24 library; FastLED (RX); ESPAsyncWebServer (TX); `millisDelay` for non-blocking timing.
+
+**Reference spec:** [docs/superpowers/specs/2026-05-17-rf-heartbeat-design.md](../specs/2026-05-17-rf-heartbeat-design.md)
+
+**Verification model:** This is bare-metal firmware with no automated test framework in the repo. Verification is build-time (`pio run`) plus a manual hardware test plan in Task 3. Do not invent or scaffold a test framework.
+
+---
+
+## Task 1: TX heartbeat, edge sends, and mode-98 transient
+
+**Files:**
+- Modify: `TX/src/main.cpp`
+  - Constants block near line 45 (replace `RETRANSMITS` with `HEARTBEAT_INTERVAL`)
+  - Auto-mode timing block near lines 51–58 (add `heartbeatDelay`)
+  - Delete `broadcastRF()` (lines 143–151)
+  - Add `sendModeRF()` helper in its place
+  - Modify `handleWSMessage()` (lines 153–203): replace burst with edge send, fix `=`/`==` bug, restructure mode-98 handling
+  - Modify `setup()` near line 279: start the heartbeat after `initRadio()`
+  - Modify `loop()` (lines 298–317): add heartbeat tick, replace burst in AUTO block with edge send
+
+Build with: `cd TX && pio run`
+
+- [ ] **Step 1: Replace `RETRANSMITS` constant with `HEARTBEAT_INTERVAL`**
+
+In `TX/src/main.cpp` at line 45, replace:
+```cpp
+const byte RETRANSMITS = 5; // how many times we retransmit every message, for reliability in noisy RF environments
+```
+with:
+```cpp
+const unsigned long HEARTBEAT_INTERVAL = 100; // ms — TX continuously rebroadcasts CurrentMode at this cadence so receivers self-heal from lost packets and late joiners catch up
+```
+
+- [ ] **Step 2: Add `heartbeatDelay` alongside `autoDelay`**
+
+In `TX/src/main.cpp` immediately after line 53 (`millisDelay autoDelay; // the delay object`), add:
+```cpp
+millisDelay heartbeatDelay; // ticks every HEARTBEAT_INTERVAL ms to rebroadcast CurrentMode
+```
+
+- [ ] **Step 3: Replace `broadcastRF()` with `sendModeRF()`**
+
+In `TX/src/main.cpp` at lines 143–151, replace the entire `broadcastRF()` function:
+```cpp
+void broadcastRF()
+{
+  for (size_t i = 0; i < RETRANSMITS; i++)
+  {
+    radio.write(&CurrentMode, sizeof(CurrentMode), true);
+    delay(10);
+  }
+  Serial.printf("CurrentMode #%d broadcasted to RF\n", CurrentMode);
+}
+```
+with:
+```cpp
+void sendModeRF(int mode)
+{
+  radio.write(&mode, sizeof(mode), true);
+}
+```
+
+No serial print on every send — the heartbeat fires 10× per second and would flood the log. The mode-change paths log separately.
+
+- [ ] **Step 4: Rewrite `handleWSMessage()`**
+
+In `TX/src/main.cpp`, replace lines 153–203 (the entire `handleWSMessage` function) with:
+```cpp
+void handleWSMessage(void *arg, uint8_t *data, size_t len)
+{
+  AwsFrameInfo *info = (AwsFrameInfo *)arg;
+  if (info->final && info->index == 0 && info->len == len && info->opcode == WS_TEXT)
+  {
+    const size_t size = JSON_OBJECT_SIZE(1);
+    StaticJsonDocument<size> json;
+    DeserializationError err = deserializeJson(json, data);
+    if (err)
+    {
+      Serial.print(F("deserializeJson() failed with code "));
+      Serial.println(err.c_str());
+      return;
+    }
+
+    int newMode = json["mode"];
+    Serial.printf("Received mode #%d\n", newMode);
+
+    // Mode 98 (strobe) is a one-shot transient. Send a single packet directly
+    // and do NOT update CurrentMode — the heartbeat must keep broadcasting
+    // the actual steady-state pattern, not 98.
+    if (newMode == 98)
+    {
+      sendModeRF(98);
+      Serial.println("Strobe transient sent (CurrentMode unchanged)");
+      return;
+    }
+
+    int previousMode = CurrentMode;
+
+    if (newMode == AUTO_MODE)
+    { // auto
+      Serial.printf("AUTO mode set ON\n");
+      newMode = autoModes[random(24)];
+      Serial.printf("CurrentMode randomised to #%d\n", newMode);
+      autoDelay.start(AUTO_TIME);
+    }
+    else if (previousMode == AUTO_MODE)
+    {
+      autoDelay.stop();
+      Serial.printf("AUTO mode set OFF\n");
+    }
+
+    CurrentMode = newMode;
+    Serial.printf("CurrentMode set to #%d\n", CurrentMode);
+
+    // Edge send: zero-latency UI response. Restart the heartbeat clock so
+    // the next heartbeat lands one full interval later, not piggy-backed.
+    sendModeRF(CurrentMode);
+    heartbeatDelay.restart();
+
+    notifyClients();
+  }
+}
+```
+
+Key things this rewrite does:
+- Short-circuits mode 98 at the top: single packet, no state change, return.
+- Fixes the `else if (CurrentMode = AUTO_MODE)` assignment bug → `else if (previousMode == AUTO_MODE)`.
+- Replaces `broadcastRF()` with `sendModeRF(CurrentMode); heartbeatDelay.restart();`.
+- Removes the now-unnecessary `previousMode` save/revert dance around mode 98 (mode 98 returns before touching `CurrentMode`).
+
+- [ ] **Step 5: Start the heartbeat in `setup()`**
+
+In `TX/src/main.cpp`, the `setup()` function around line 279 currently calls `initRadio();`. Immediately after that line, add:
+```cpp
+  heartbeatDelay.start(HEARTBEAT_INTERVAL);
+```
+
+The line should now look like:
+```cpp
+  initRadio();
+  heartbeatDelay.start(HEARTBEAT_INTERVAL);
+```
+
+- [ ] **Step 6: Add heartbeat tick and update AUTO block in `loop()`**
+
+In `TX/src/main.cpp`, replace the entire `loop()` function (lines 298–317):
+```cpp
+void loop()
+{
+  dnsServer.processNextRequest();
+  ws.cleanupClients();
+
+  if (autoDelay.justFinished())
+  {
+    // set a random mode
+    CurrentMode = autoModes[random(24)];
+    Serial.printf("CurrentMode randomised to #%d\n", CurrentMode);
+
+    broadcastRF();
+    notifyClients();
+
+    autoDelay.repeat(); // repeat
+    Serial.println("autoDelay restarted");
+  }
+
+  delay(DNS_INTERVAL);  // seems to help with stability, if you are doing other things in the loop this may not be needed
+}
+```
+with:
+```cpp
+void loop()
+{
+  dnsServer.processNextRequest();
+  ws.cleanupClients();
+
+  if (autoDelay.justFinished())
+  {
+    // set a random mode
+    CurrentMode = autoModes[random(24)];
+    Serial.printf("CurrentMode randomised to #%d\n", CurrentMode);
+
+    sendModeRF(CurrentMode);
+    heartbeatDelay.restart();
+    notifyClients();
+
+    autoDelay.repeat(); // repeat
+    Serial.println("autoDelay restarted");
+  }
+
+  if (heartbeatDelay.justFinished())
+  {
+    sendModeRF(CurrentMode);
+    heartbeatDelay.repeat();
+  }
+
+  delay(DNS_INTERVAL);  // seems to help with stability, if you are doing other things in the loop this may not be needed
+}
+```
+
+- [ ] **Step 7: Build the TX firmware**
+
+Run: `cd TX && pio run`
+
+Expected: build completes with no errors. Warnings about the now-unused `previousMode` variable in earlier code paths should be gone (the rewrite removed it). No reference to `broadcastRF` or `RETRANSMITS` should remain in the file.
+
+If the build fails, the most likely cause is a missed brace or a stale call site. Run `grep -n "broadcastRF\|RETRANSMITS" TX/src/main.cpp` — both greps should return nothing.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add TX/src/main.cpp
+git commit -m "feat(TX): replace 5x burst with 100ms heartbeat + zero-latency edge sends
+
+TX now continuously rebroadcasts CurrentMode at 10 Hz so receivers
+self-heal from lost packets and late joiners catch up within one
+interval. UI mode changes still send immediately for zero perceptible
+latency. Mode 98 (strobe) is a single-packet transient that bypasses
+CurrentMode so the heartbeat never holds it. Also fixes a latent
+assignment-vs-comparison bug in the AUTO-mode revert path."
+```
+
+---
+
+## Task 2: RX idempotent receive and self-contained 5-flash strobe
+
+**Files:**
+- Modify: `RX/src/main.cpp`
+  - `readRadio()` at lines 161–177 (add idempotency guard)
+  - `case 98` at lines 336–343 (5-flash loop)
+
+Build with: `cd RX && pio run`
+
+- [ ] **Step 1: Make `readRadio()` idempotent**
+
+In `RX/src/main.cpp`, replace the entire `readRadio()` function at lines 161–177:
+```cpp
+void readRadio()
+{
+  byte pipe;
+
+  if (radio.available(&pipe))
+  { // is there a payload?
+    int payload;
+    radio.read(&payload, sizeof(payload)); // get incoming payload
+    ledMode = payload;
+
+    Serial.print("Radio RX data: ");
+    Serial.println(ledMode);
+
+    // clear all pixels ready for the new mode
+    FastLED.clear();
+  }
+}
+```
+with:
+```cpp
+void readRadio()
+{
+  byte pipe;
+
+  if (radio.available(&pipe))
+  { // is there a payload?
+    int payload;
+    radio.read(&payload, sizeof(payload)); // get incoming payload
+
+    // Idempotent: heartbeats arrive ~10x per second carrying the current
+    // mode. Only react when the mode actually changes — otherwise we'd
+    // wipe running patterns at 10 Hz. This equality guard is also what
+    // keeps mid-strobe heartbeats from re-triggering case 98 (which
+    // restores ledMode to the prior mode after flashing).
+    if (payload != ledMode)
+    {
+      ledMode = payload;
+      Serial.print("Radio RX mode change: ");
+      Serial.println(ledMode);
+      FastLED.clear();
+    }
+  }
+}
+```
+
+- [ ] **Step 2: Replace `case 98` with a self-contained 5-flash loop**
+
+In `RX/src/main.cpp`, replace lines 336–343:
+```cpp
+  case 98:
+    // quick white strobe - flashes multiple times because TX resends mode 3 times :-|
+    fill_solid(leds, numLeds, CRGB::White);
+    FastLED.show();
+    FastLED.delay(30);
+    FastLED.clear();
+    ledMode = currentMode; // reinstate the previous mode
+    break;
+```
+with:
+```cpp
+  case 98:
+    // 5-flash white strobe — TX now sends mode 98 as a single packet,
+    // so the RX produces all 5 flashes from one receive. Total ~300ms.
+    // Heartbeats arriving during this loop are buffered by the nRF24's
+    // 3-deep RX FIFO and are duplicates of the prior mode, so the
+    // idempotency guard in readRadio() will no-op them after the strobe.
+    for (int i = 0; i < 5; i++)
+    {
+      fill_solid(leds, numLeds, CRGB::White);
+      FastLED.show();
+      FastLED.delay(30);
+      FastLED.clear();
+      FastLED.show();
+      FastLED.delay(30);
+    }
+    ledMode = currentMode; // restore prior mode (load-bearing — otherwise loop re-enters case 98)
+    break;
+```
+
+- [ ] **Step 3: Build the RX firmware**
+
+Run: `cd RX && pio run`
+
+Expected: build completes with no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add RX/src/main.cpp
+git commit -m "feat(RX): idempotent receive + self-contained 5-flash strobe
+
+readRadio() now only mutates state when the received mode differs from
+the running one, so the new TX heartbeat (10 Hz duplicates of the
+current mode) does not disrupt running patterns. case 98 produces all
+5 strobe flashes from a single received packet, since TX no longer
+bursts."
+```
+
+---
+
+## Task 3: Hardware verification
+
+**Files:** none modified.
+
+This task is the manual acceptance test plan from the design spec. It must be run on real hardware: one TX and at least two RX units (more is better for catch-up tests). Both firmwares from Tasks 1 & 2 must be flashed before starting.
+
+- [ ] **Step 1: Flash both firmwares**
+
+```bash
+cd TX && pio run -t upload
+cd ../RX && pio run -t upload   # repeat for each receiver
+```
+
+Open serial monitors on both: `pio device monitor -b 115200`.
+
+- [ ] **Step 2: Verify heartbeat is firing**
+
+With TX powered and no UI interaction:
+- TX serial: silent (no per-heartbeat log — by design, to avoid spam).
+- RX serial: shows the initial "Radio RX mode change: …" once shortly after the RX boots, then silence — confirming heartbeats are arriving but the idempotency guard is suppressing log output.
+
+Quick sanity check that heartbeats are actually on the air: power-cycle the RX and observe it picks up the current mode within ≤100 ms of its radio init logging.
+
+- [ ] **Step 3: Verify catch-up after RX reboot**
+
+TX in any non-default mode (e.g., select Swan Samba twinkle in the UI). Power-cycle an RX. Expected: drum joins the running pattern within one heartbeat after radio init completes, with no user action needed.
+
+Repeat 2–3 times to confirm consistency.
+
+- [ ] **Step 4: Verify zero-latency UI mode changes**
+
+Watch a drum while tapping different modes in the UI. Each tap should produce a visually immediate response — no perceptible lag. (The edge send fires on the WS event, well before the next heartbeat tick.)
+
+- [ ] **Step 5: Verify no flicker on running patterns**
+
+For each of these modes, run for ≥30 s and look for any 10 Hz visual disturbance:
+- 63 (Swan Samba twinkle)
+- 23 (Swan Samba chase)
+- 50 (wood fire)
+- 99 (rainbow)
+
+Expected: patterns animate cleanly with no periodic glitch. If you see 10 Hz flicker, the idempotency guard in `readRadio()` is not working — re-check Task 2 Step 1.
+
+- [ ] **Step 6: Verify strobe (mode 98)**
+
+With any static mode running (e.g., mode 1 solid green):
+- Tap the strobe button once.
+- Expected: exactly 5 white flashes, then back to solid green with no visible glitch.
+
+Repeat with twinkle running: 5 flashes, then twinkle resumes seamlessly.
+
+- [ ] **Step 7: Verify AUTO mode**
+
+Enable AUTO in the UI. Expected:
+- A random mode is selected immediately (drum changes visibly within 100 ms).
+- Every 30 s a new random mode is chosen and broadcast immediately.
+- UI display tracks the current mode.
+
+- [ ] **Step 8: Verify lossy-link recovery (optional but recommended)**
+
+Walk an RX to the edge of radio range. Expected: patterns remain stable (heartbeats keep refreshing); mode changes still arrive within a few hundred ms even if the first edge packet is dropped.
+
+- [ ] **Step 9: Document and ship**
+
+If all checks pass, the implementation is complete. Suggested follow-ups (out of scope for this plan, but worth raising with the maintainer):
+- Add a line to `README.md` flagging that pre-heartbeat receivers are incompatible with new-heartbeat TX, so all units must be flashed together.
+- Consider a PR if changes were made on a branch.

--- a/docs/superpowers/specs/2026-05-17-rf-heartbeat-design.md
+++ b/docs/superpowers/specs/2026-05-17-rf-heartbeat-design.md
@@ -1,0 +1,178 @@
+# RF Heartbeat — Design
+
+**Date:** 2026-05-17
+**Status:** Approved (pending spec review)
+
+## Problem
+
+The current firmware transmits each mode change as a 5× burst over ~50 ms, then goes silent until the next user action or AUTO-mode timer. Two failure modes follow:
+
+1. **Lost burst.** If all 5 packets of a burst are lost (noisy RF, momentary obstruction, RX briefly busy), the affected drum misses the mode change entirely until the next change.
+2. **No catch-up.** A drum that reboots, loses power, or comes online late has no way to learn the current mode until the user changes mode again.
+
+## Goal
+
+A drum that misses any individual transmission, or that boots / reboots at any time, catches up to the current pattern within a fraction of a second — without measurable battery impact on the transmitter.
+
+## Approach
+
+The TX broadcasts the current mode on a fixed-interval heartbeat (100 ms). User-driven mode changes are sent immediately as a single packet *in addition to* the heartbeat — preserving zero-perceptible-latency UI response. The RX treats receives as idempotent: only reset state and clear the strip when the received mode differs from what it's currently running, so heartbeat duplicates do not disrupt running patterns.
+
+This single mechanism solves both failure modes. Lost packets self-heal within one heartbeat interval. Late-joining receivers learn the current mode within one heartbeat interval.
+
+## Design parameters
+
+| Parameter | Value | Rationale |
+|---|---|---|
+| Heartbeat interval | 100 ms | Worst-case catch-up well under user-perceptible threshold; ≤0.6 % RF duty cycle. |
+| Edge send on mode change | 1 packet, immediate | Zero-latency UI response; resets heartbeat clock. |
+| Burst on mode change | None | Removed; single packet + heartbeat-self-heal supersedes it. |
+| Payload | Unchanged (`int` mode value) | No protocol change needed. |
+| Direction | Unchanged (TX-only) | No bidirectional / ack protocol. |
+
+## TX changes ([TX/src/main.cpp](../../../TX/src/main.cpp))
+
+### New state
+- `const unsigned long HEARTBEAT_INTERVAL = 100; // ms`
+- `millisDelay heartbeatDelay;`
+- Started in `setup()` after `initRadio()`, repeated in `loop()`.
+
+### New helper
+```cpp
+void sendModeRF(int mode)
+{
+  radio.write(&mode, sizeof(mode), true);
+}
+```
+Single send. No `delay()`, no loop. Used by both the heartbeat tick and the edge sends.
+
+### Heartbeat tick
+In `loop()`:
+```cpp
+if (heartbeatDelay.justFinished())
+{
+  sendModeRF(CurrentMode);
+  heartbeatDelay.repeat();
+}
+```
+
+### Edge sends (zero-latency)
+On any UI mode change in [handleWSMessage()](../../../TX/src/main.cpp):
+- Update `CurrentMode` as today.
+- `sendModeRF(CurrentMode); heartbeatDelay.restart();` so the next heartbeat tick lands one full interval later, not piggy-backed.
+
+On AUTO-mode timer rollover in `loop()`:
+- Pick new random mode, update `CurrentMode`.
+- `sendModeRF(CurrentMode); heartbeatDelay.restart();`
+
+### Mode 98 (strobe) — transient handling
+`CurrentMode` must never hold `98`, otherwise the heartbeat would broadcast it indefinitely. In `handleWSMessage`, when `newMode == 98`:
+- Call `sendModeRF(98)` directly (single packet, bypass the heartbeat).
+- Do **not** update `CurrentMode`.
+- Do **not** restart `heartbeatDelay` — the heartbeat continues broadcasting the actual prior mode unchanged.
+
+This deletes the existing "save previousMode / revert after broadcast" dance — no longer needed.
+
+### Cleanup
+- Delete the `broadcastRF()` function.
+- Delete the `RETRANSMITS` constant.
+- Fix the assignment-vs-comparison bug at the existing `else if (CurrentMode = AUTO_MODE)` line — should be `else if (previousMode == AUTO_MODE)`.
+
+## RX changes ([RX/src/main.cpp](../../../RX/src/main.cpp))
+
+### Change 1 — idempotent receive
+[readRadio()](../../../RX/src/main.cpp) only mutates state when the received mode differs from the current `ledMode`. Duplicate heartbeats are no-ops.
+
+```cpp
+void readRadio()
+{
+  byte pipe;
+  if (radio.available(&pipe))
+  {
+    int payload;
+    radio.read(&payload, sizeof(payload));
+    if (payload != ledMode)
+    {
+      ledMode = payload;
+      Serial.print("Radio RX mode change: ");
+      Serial.println(ledMode);
+      FastLED.clear();
+    }
+    // else: heartbeat duplicate; ignore. The equality guard is also what
+    // protects mid-strobe heartbeats from re-triggering case 98.
+  }
+}
+```
+
+### Change 2 — case 98 self-contained 5-flash strobe
+The TX now sends a single mode-98 packet (no burst). The RX must produce all 5 flashes from one receive:
+
+```cpp
+case 98:
+  // 5-flash white strobe (timing matches old 5x-burst behaviour)
+  for (int i = 0; i < 5; i++)
+  {
+    fill_solid(leds, numLeds, CRGB::White);
+    FastLED.show();
+    FastLED.delay(30);
+    FastLED.clear();
+    FastLED.show();
+    FastLED.delay(30);
+  }
+  ledMode = currentMode; // restore prior mode; otherwise loop re-enters case 98
+  break;
+```
+
+The existing `currentMode` capture at the top of `loop()` makes the revert correct — no change there.
+
+### Mid-strobe safety
+While the strobe loop runs (~300 ms), `readRadio()` is not being called. The nRF24L01's 3-deep hardware RX FIFO buffers incoming heartbeats. After the strobe completes:
+- Buffered heartbeats are duplicates of the prior mode → equality check makes them no-ops.
+- If the user changed to a *different* mode during the strobe (rare), the new-mode packet sits in FIFO or arrives on the next heartbeat, and the equality check picks it up — at most ~100 ms after the strobe ends.
+
+The 5 flashes are unconditional once a mode-98 packet is received.
+
+## Edge cases considered
+
+| Scenario | Behaviour |
+|---|---|
+| RX boots / reboots mid-pattern | Catches up to current mode within ≤100 ms. |
+| TX heartbeat packet lost | Next heartbeat ≤100 ms later self-heals. |
+| Edge packet (mode change) lost | RX acts on next heartbeat ≤100 ms later. Strictly better than today (where a lost burst means a permanently missed change). |
+| User picks same mode twice | Edge packet sent, but RX equality check makes it a no-op. No visible flicker. |
+| User picks different mode during strobe | Strobe completes (5 flashes); new mode applied immediately after. |
+| AUTO mode rollover | Random new mode sent immediately via edge send; heartbeat continues with that mode. |
+| Mid-strobe heartbeats | Buffered in nRF24 FIFO, then equality-no-op'd after strobe. |
+| Mode 98 in AUTO randomiser | N/A — AUTO mode array does not include 98. |
+
+## Power impact
+
+- ~10 single-packet transmits per second from heartbeat.
+- nRF24L01 at 2 Mbps, 4-byte payload: ~600 µs on-air per packet → ~6 ms/s TX time = 0.6 % radio duty cycle.
+- nRF24L01 TX current ~11 mA; average draw increase ≪ 100 µA.
+- ESP32 baseline ~80 mA. Heartbeat is well below measurement noise on USB battery runtime.
+
+## Verification (manual hardware test plan)
+
+No automated test framework in the project; verification is on hardware.
+
+1. **Heartbeat firing.** TX powered, no UI activity: serial log shows `sendModeRF` every ~100 ms; RX serial shows no "mode change" entries.
+2. **Catch-up.** TX in mode 63. Power-cycle an RX. Drum joins the pattern within ≤100 ms of boot completion + radio init.
+3. **Zero-latency edge.** Tap a new mode in the UI; drum responds with no perceptible delay.
+4. **Lossy-link recovery.** At edge of radio range, patterns remain stable; mode changes arrive within a few hundred ms even if the initial edge packet is dropped.
+5. **Strobe.** Tap mode 98 with a static pattern running: exactly 5 white flashes, then prior pattern resumes cleanly.
+6. **No flicker on running patterns.** Run twinkle, chase, fire, rainbow ≥30 s each — no visible flicker from heartbeats.
+7. **AUTO mode.** Enable AUTO; 30 s rotation continues; new random mode is broadcast immediately on rollover.
+
+## Deployment note
+
+TX and all RX units must be flashed together. A *new TX + old RX* combination is visibly broken — the old RX clears LEDs on every received packet, so heartbeats will wipe running patterns at 10 Hz. *New RX + old TX* works but loses the catch-up benefit. README should gain a one-line "upgrading from pre-heartbeat firmware" note.
+
+## Explicitly out of scope
+
+- Per-RX addressing or bidirectional protocol.
+- Sequence numbers / packet IDs (payload equality is sufficient).
+- New modes or effects.
+- Refactoring the giant switch in RX `loop()`.
+- Configurable heartbeat interval via ini file (compile-time `#define` is sufficient).
+- TX web UI changes (none needed).

--- a/docs/superpowers/specs/2026-05-17-rf-heartbeat-design.md
+++ b/docs/superpowers/specs/2026-05-17-rf-heartbeat-design.md
@@ -76,7 +76,7 @@ This deletes the existing "save previousMode / revert after broadcast" dance —
 ### Cleanup
 - Delete the `broadcastRF()` function.
 - Delete the `RETRANSMITS` constant.
-- Fix the assignment-vs-comparison bug at the existing `else if (CurrentMode = AUTO_MODE)` line — should be `else if (previousMode == AUTO_MODE)`.
+- Fix the assignment-vs-comparison bug at the existing `else if (CurrentMode = AUTO_MODE)` line. The naive fix `previousMode == AUTO_MODE` does not work because `CurrentMode` never actually holds `AUTO_MODE` while AUTO is running (the AUTO branch overwrites `newMode` with a real mode value before assigning it to `CurrentMode`). Use `autoDelay.isRunning()` as the source of truth for "AUTO is currently active". This also lets us drop the `previousMode` local — nothing else reads it once mode 98 short-circuits at the top.
 
 ## RX changes ([RX/src/main.cpp](../../../RX/src/main.cpp))
 


### PR DESCRIPTION
## Summary

Replaces the TX's 5×-burst-on-mode-change with a 100 ms continuous heartbeat that rebroadcasts the current mode. Drums that miss any individual packet, that reboot, or that come online late catch up to the current pattern within ~100 ms — instead of being stranded on the previous mode until the next user action.

UI mode changes are still acted on with zero perceptible latency: in addition to the heartbeat, every mode change sends an immediate edge packet and resets the heartbeat clock.

## Changes

**TX (`TX/src/main.cpp`):**
- New `HEARTBEAT_INTERVAL = 100 ms` and `heartbeatDelay`; `loop()` ticks once per interval and calls `sendModeRF(CurrentMode)`.
- WS mode-change handler and AUTO-mode rollover both fire an immediate edge packet via `sendModeRF()` and `heartbeatDelay.restart()` to keep cadence clean.
- Mode 98 (strobe) is now a transient: TX sends a single mode-98 packet and returns *without* updating `CurrentMode`, so the heartbeat never broadcasts 98.
- Removed `broadcastRF()` and `RETRANSMITS`.
- Fixed a latent assignment-vs-equality bug in the AUTO-exit predicate (`CurrentMode = AUTO_MODE` → `autoDelay.isRunning()`). The naive `previousMode == AUTO_MODE` fix doesn't work because `CurrentMode` never holds `AUTO_MODE` while AUTO is running; using `autoDelay.isRunning()` as the source of truth is both correct and clearer.

**RX (`RX/src/main.cpp`):**
- `readRadio()` is now idempotent — only updates `ledMode` and clears the strip when the received mode actually differs. Duplicate heartbeats are no-ops, so running patterns aren't disrupted by the 10 Hz traffic.
- `case 98` produces all 5 strobe flashes from a single received packet via a self-contained loop (since TX no longer bursts).

**Docs:** Spec, plan, and README updated. README now describes the heartbeat protocol and includes a firmware-compatibility note (TX and RX must be flashed together — a new TX paired with an old RX will visibly malfunction because the old RX clears LEDs on every received packet).

## Design & plan

- Spec: [`docs/superpowers/specs/2026-05-17-rf-heartbeat-design.md`](../blob/claude/kind-colden-45af45/docs/superpowers/specs/2026-05-17-rf-heartbeat-design.md)
- Plan: [`docs/superpowers/plans/2026-05-17-rf-heartbeat.md`](../blob/claude/kind-colden-45af45/docs/superpowers/plans/2026-05-17-rf-heartbeat.md)

## Power impact

Heartbeat adds ~10 single-packet transmits/sec ≈ 0.6% radio duty cycle. nRF24 TX current is ~11 mA only while transmitting, so average draw bump is well under 100 µA — negligible against the ESP32 baseline of ~80 mA. No measurable effect on USB-battery runtime.

## Test plan

Both firmwares build cleanly (`pio run` on TX and RX). There is no automated test framework for this project by design — verification is on real hardware. Suggested acceptance checks (per the plan's Task 3):

- [ ] **Catch-up:** with TX in any non-default mode, power-cycle an RX. It should join the running pattern within ~100 ms of radio init.
- [ ] **Zero-latency:** tap mode changes in the UI — no perceptible delay before drums respond.
- [ ] **No flicker on running patterns:** run twinkle, chase, fire, and rainbow for ≥30 s each. No 10 Hz visual disturbance.
- [ ] **Strobe:** tap mode 98 against a static pattern — exactly 5 white flashes, then prior pattern resumes seamlessly.
- [ ] **AUTO mode:** enable AUTO, confirm 30 s rotation continues and each new random mode is broadcast immediately.
- [ ] **Exit AUTO cleanly:** enable AUTO, then pick a non-AUTO mode — confirm AUTO stays off (this is the bug the `autoDelay.isRunning()` fix addresses; previously the autoDelay kept firing and yanked the drum back to a random mode 30 s later).
- [ ] **Lossy-link recovery (optional):** walk an RX to the edge of radio range — patterns stay stable and mode changes still arrive within a few hundred ms.

## Reviewer notes

- All firmware units must be flashed together. New TX + old RX is intentionally not wire-compatible (see README firmware-compatibility note).
- The 5-flash strobe loop blocks the RX for ~300 ms. During that window any incoming heartbeats are buffered in the nRF24's 3-deep RX FIFO and become no-ops via the idempotency guard once the strobe completes.
- This change went through brainstorming → spec → plan → per-task implementation with spec-compliance and code-quality reviews, then a final whole-implementation review. The AUTO-exit predicate fix (`6d56a8c`) was a regression caught by the code-quality reviewer and patched before merge; the spec/plan were corrected to match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)