### PR TITLE
Migrate RX firmware from SPIFFS to LittleFS (preserving per-unit config)

### DIFF
--- a/RX/platformio.ini
+++ b/RX/platformio.ini
@@ -12,9 +12,9 @@
 platform = espressif8266
 board = esp12e
 framework = arduino
+board_build.filesystem = littlefs
 monitor_speed = 115200
 lib_deps = 
 	nrf24/RF24@^1.4.10
 	fastled/FastLED@^3.8.0
-	yurilopes/SPIFFSIniFile@^1.0.0
 monitor_filters = esp8266_exception_decoder

--- a/RX/src/main.cpp
+++ b/RX/src/main.cpp
@@ -15,7 +15,8 @@
 #include <RF24.h>
 #define FASTLED_ALLOW_INTERRUPTS 0
 #include <FastLED.h>
-#include "FS.h"
+#include <FS.h>
+#include <LittleFS.h>
 #include <SPIFFSIniFile.h>
 
 #include "prototypes.h"
@@ -44,6 +45,65 @@ int ledMode = -1;                  // The currently active pattern
 unsigned long IDLETIMEOUT = 30000; // Time to wait before doing our own thing
 
 void (*resetFunc)(void) = 0; // declare reset function @ address 0
+
+// Read /config.ini from LittleFS. Returns true if the file opened
+// successfully (regardless of which keys were present). Unknown keys
+// and sections are silently ignored, so future config additions are
+// non-breaking.
+static bool readConfig(const char *path, int &numLeds, int &drumType)
+{
+  File f = LittleFS.open(path, "r");
+  if (!f)
+  {
+    return false;
+  }
+
+  char section[16] = "";
+  while (f.available())
+  {
+    String line = f.readStringUntil('\n');
+    line.trim();
+    if (line.length() == 0)
+      continue;
+    if (line.startsWith(";") || line.startsWith("#"))
+      continue;
+
+    if (line.startsWith("["))
+    {
+      int end = line.indexOf(']');
+      if (end > 1)
+      {
+        String s = line.substring(1, end);
+        s.trim();
+        s.toCharArray(section, sizeof(section));
+      }
+      continue;
+    }
+
+    int eq = line.indexOf('=');
+    if (eq < 0)
+      continue;
+    String key = line.substring(0, eq);
+    String val = line.substring(eq + 1);
+    key.trim();
+    val.trim();
+
+    if (strcmp(section, "leds") == 0 && key == "count")
+    {
+      numLeds = val.toInt();
+      Serial.print("Got numLeds from config: ");
+      Serial.println(numLeds);
+    }
+    else if (strcmp(section, "drum") == 0 && key == "type")
+    {
+      drumType = val.toInt();
+      Serial.print("Got drum type from config: ");
+      Serial.println(drumType);
+    }
+  }
+  f.close();
+  return true;
+}
 
 void showStatus(struct CRGB *targetArray, const struct CRGB &color)
 {

--- a/RX/src/main.cpp
+++ b/RX/src/main.cpp
@@ -105,6 +105,80 @@ static bool readConfig(const char *path, int &numLeds, int &drumType)
   return true;
 }
 
+// One-time migration: if LittleFS isn't mounted (the flash region is
+// still SPIFFS-formatted), read /config.ini from SPIFFS into RAM,
+// format LittleFS, and write the file back. Idempotent on subsequent
+// boots — LittleFS.begin() succeeds first try and the SPIFFS branch
+// never runs. Returns true if LittleFS is mounted on exit.
+static bool mountFsWithMigration(const char *configPath)
+{
+  if (LittleFS.begin())
+  {
+    return true;
+  }
+
+  Serial.println("LittleFS not present; attempting SPIFFS migration");
+
+  const size_t BUF_SZ = 1024;
+  char buffer[BUF_SZ];
+  size_t bufLen = 0;
+  bool haveConfig = false;
+
+  if (SPIFFS.begin())
+  {
+    if (SPIFFS.exists(configPath))
+    {
+      File f = SPIFFS.open(configPath, "r");
+      if (f)
+      {
+        bufLen = f.readBytes(buffer, BUF_SZ);
+        if (f.available())
+        {
+          Serial.println("WARN: config.ini larger than 1024 bytes; trailing data lost");
+        }
+        f.close();
+        haveConfig = bufLen > 0;
+        Serial.printf("Read %u bytes of config from SPIFFS\n", (unsigned)bufLen);
+      }
+    }
+    else
+    {
+      Serial.println("No /config.ini on SPIFFS; LittleFS will start empty");
+    }
+    SPIFFS.end();
+  }
+  else
+  {
+    Serial.println("SPIFFS also unmountable; formatting LittleFS fresh");
+  }
+
+  if (!LittleFS.format())
+  {
+    Serial.println("LittleFS.format() failed");
+    return false;
+  }
+  if (!LittleFS.begin())
+  {
+    Serial.println("LittleFS.begin() after format failed");
+    return false;
+  }
+
+  if (haveConfig)
+  {
+    File out = LittleFS.open(configPath, "w");
+    if (!out)
+    {
+      Serial.println("Could not open /config.ini for write on LittleFS");
+      return true;
+    }
+    out.write((const uint8_t *)buffer, bufLen);
+    out.close();
+    Serial.println("Wrote config.ini to LittleFS");
+  }
+
+  return true;
+}
+
 void showStatus(struct CRGB *targetArray, const struct CRGB &color)
 {
   EVERY_N_MILLIS(1000)

--- a/RX/src/main.cpp
+++ b/RX/src/main.cpp
@@ -17,7 +17,6 @@
 #include <FastLED.h>
 #include <FS.h>
 #include <LittleFS.h>
-#include <SPIFFSIniFile.h>
 
 #include "prototypes.h"
 
@@ -216,52 +215,25 @@ void setup()
 
 #pragma region CONFIGFILE
 
-  // to read config file
-  const byte bufferLen = 80;
-  char buffer[bufferLen];
-
   const char *filename = "/config.ini";
 
-  // Mount the SPIFFS
-  if (!SPIFFS.begin())
+  if (!mountFsWithMigration(filename))
   {
-    Serial.println("SPIFFS.begin() failed");
+    Serial.println("Filesystem mount failed");
     ledMode = -2;
   }
-
-  SPIFFSIniFile ini(filename);
-  if (!ini.open())
+  else
   {
-    Serial.print("ini file ");
-    Serial.print(filename);
-    Serial.println(" does not exist");
-    ledMode = -2;
-  }
-
-  // Check the file is valid. This can be used to warn if any lines
-  // are longer than the buffer.
-  if (!ini.validate(buffer, bufferLen))
-  {
-    Serial.print("ini file ");
-    Serial.print(ini.getFilename());
-    Serial.print(" not valid: ");
-    ledMode = -2;
+    int drumType = 0;
+    if (!readConfig(filename, numLeds, drumType))
+    {
+      Serial.print("Config file ");
+      Serial.print(filename);
+      Serial.println(" not found; using defaults");
+    }
   }
 
 #pragma endregion CONFIGFILE
-
-  if (ini.getValue("leds", "count", buffer, bufferLen, numLeds))
-  {
-    Serial.print("Got numLeds from config: ");
-    Serial.println(numLeds);
-  }
-  int drumType = 0;
-  if (ini.getValue("drum", "type", buffer, bufferLen, drumType))
-  {
-    Serial.print("Got drum type from config: ");
-    Serial.println(drumType);
-  }
-  ini.close();
 
   Serial.print("Setting up LEDs... ");
   FastLED.addLeds<WS2812, DATA_PIN, GRB>(leds, numLeds).setCorrection(TypicalPixelString);

--- a/docs/superpowers/plans/2026-05-17-rx-littlefs-migration.md
+++ b/docs/superpowers/plans/2026-05-17-rx-littlefs-migration.md
@@ -1,0 +1,411 @@
+# RX LittleFS Migration Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Migrate the RX firmware off SPIFFS onto LittleFS while preserving the per-unit `/config.ini` already stored on each deployed drum.
+
+**Architecture:** Three pieces in `RX/` only — a tiny in-file INI parser, a one-time SPIFFS-read / LittleFS-format / config-rewrite migration helper that runs on first boot, and a `platformio.ini` swap to LittleFS. After the first boot, the migration path is dormant and the firmware behaves as a plain LittleFS application.
+
+**Tech Stack:** Arduino framework on ESP8266 (ESP12E), PlatformIO build, ESP8266 Arduino core 3.x (provides both `SPIFFS` from `FS.h` and `LittleFS` from `LittleFS.h`).
+
+**Spec:** [docs/superpowers/specs/2026-05-17-rx-littlefs-migration-design.md](../specs/2026-05-17-rx-littlefs-migration-design.md)
+
+---
+
+## Note on testing
+
+This project has no host unit test framework configured (the `RX/test/` directory contains only the default README). The verification gate for each task is a clean PlatformIO build:
+
+```
+cd RX && pio run -e esp12e
+```
+
+If the build fails after a task, that is the failing-test signal — the task is not complete until it succeeds.
+
+On-device verification (config preservation across the SPIFFS→LittleFS transition) cannot be done from this environment and must be performed by the user on a real drum unit after the plan is complete. The serial-monitor output of `mountFsWithMigration()` is the diagnostic surface for that test — keep its `Serial.println` calls intact.
+
+## File Structure
+
+Two files modified; no new files.
+
+- `RX/platformio.ini` — `lib_deps` swap, add `board_build.filesystem = littlefs`
+- `RX/src/main.cpp` — replace `#include <SPIFFSIniFile.h>`, add two static helpers (`readConfig`, `mountFsWithMigration`), replace the `#pragma region CONFIGFILE` block
+
+## Task Ordering
+
+Tasks 1–2 add new functions but do not call them — the firmware still builds with `SPIFFSIniFile` and SPIFFS active. Task 3 is the atomic switchover: it removes the old code path, adds the new call sites, and changes `platformio.ini` in a single commit because removing the `SPIFFSIniFile` dependency before the call sites are gone would break the build.
+
+---
+
+### Task 1: Add the INI parser helper
+
+**Files:**
+- Modify: `RX/src/main.cpp` (insert helper above `setup()`)
+
+- [ ] **Step 1: Verify baseline build is clean**
+
+Run:
+```
+cd RX && pio run -e esp12e
+```
+Expected: `===== [SUCCESS] Took ... =====`. If this fails, stop and report — the baseline is broken.
+
+- [ ] **Step 2: Add `#include <LittleFS.h>` to the include block**
+
+In `RX/src/main.cpp`, find the existing include block (around lines 12–19). Change the `#include "FS.h"` and `#include <SPIFFSIniFile.h>` pair to:
+
+```cpp
+#include <FS.h>
+#include <LittleFS.h>
+#include <SPIFFSIniFile.h>
+```
+
+Rationale: keep `SPIFFSIniFile.h` for now (still used by the existing CONFIGFILE block — removed in Task 3). Add `<LittleFS.h>` so the new helper compiles. Switch `"FS.h"` to `<FS.h>` for consistency with how the ESP8266 core ships it (cosmetic; both work).
+
+- [ ] **Step 3: Add the `readConfig` static helper**
+
+In `RX/src/main.cpp`, insert this function immediately after the `void (*resetFunc)(void) = 0;` line (around line 46) and before `showStatus`:
+
+```cpp
+// Read /config.ini from LittleFS. Returns true if the file opened
+// successfully (regardless of which keys were present). Unknown keys
+// and sections are silently ignored, so future config additions are
+// non-breaking.
+static bool readConfig(const char *path, int &numLeds, int &drumType)
+{
+  File f = LittleFS.open(path, "r");
+  if (!f)
+  {
+    return false;
+  }
+
+  char section[16] = "";
+  while (f.available())
+  {
+    String line = f.readStringUntil('\n');
+    line.trim();
+    if (line.length() == 0)
+      continue;
+    if (line.startsWith(";") || line.startsWith("#"))
+      continue;
+
+    if (line.startsWith("["))
+    {
+      int end = line.indexOf(']');
+      if (end > 1)
+      {
+        String s = line.substring(1, end);
+        s.trim();
+        s.toCharArray(section, sizeof(section));
+      }
+      continue;
+    }
+
+    int eq = line.indexOf('=');
+    if (eq < 0)
+      continue;
+    String key = line.substring(0, eq);
+    String val = line.substring(eq + 1);
+    key.trim();
+    val.trim();
+
+    if (strcmp(section, "leds") == 0 && key == "count")
+    {
+      numLeds = val.toInt();
+      Serial.print("Got numLeds from config: ");
+      Serial.println(numLeds);
+    }
+    else if (strcmp(section, "drum") == 0 && key == "type")
+    {
+      drumType = val.toInt();
+      Serial.print("Got drum type from config: ");
+      Serial.println(drumType);
+    }
+  }
+  f.close();
+  return true;
+}
+```
+
+- [ ] **Step 4: Build to verify**
+
+Run:
+```
+cd RX && pio run -e esp12e
+```
+Expected: build SUCCESS. A `defined but not used` warning on `readConfig` is acceptable at this stage — it gets called in Task 3.
+
+- [ ] **Step 5: Commit**
+
+```
+git add RX/src/main.cpp
+git commit -m "feat(rx): add custom INI parser for LittleFS config"
+```
+
+---
+
+### Task 2: Add the SPIFFS → LittleFS migration helper
+
+**Files:**
+- Modify: `RX/src/main.cpp` (insert second helper above `setup()`)
+
+- [ ] **Step 1: Add `mountFsWithMigration` below `readConfig`**
+
+In `RX/src/main.cpp`, insert this function immediately after the `readConfig` function added in Task 1:
+
+```cpp
+// One-time migration: if LittleFS isn't mounted (the flash region is
+// still SPIFFS-formatted), read /config.ini from SPIFFS into RAM,
+// format LittleFS, and write the file back. Idempotent on subsequent
+// boots — LittleFS.begin() succeeds first try and the SPIFFS branch
+// never runs. Returns true if LittleFS is mounted on exit.
+static bool mountFsWithMigration(const char *configPath)
+{
+  if (LittleFS.begin())
+  {
+    return true;
+  }
+
+  Serial.println("LittleFS not present; attempting SPIFFS migration");
+
+  const size_t BUF_SZ = 1024;
+  char buffer[BUF_SZ];
+  size_t bufLen = 0;
+  bool haveConfig = false;
+
+  if (SPIFFS.begin())
+  {
+    if (SPIFFS.exists(configPath))
+    {
+      File f = SPIFFS.open(configPath, "r");
+      if (f)
+      {
+        bufLen = f.readBytes(buffer, BUF_SZ);
+        if (f.available())
+        {
+          Serial.println("WARN: config.ini larger than 1024 bytes; trailing data lost");
+        }
+        f.close();
+        haveConfig = bufLen > 0;
+        Serial.printf("Read %u bytes of config from SPIFFS\n", (unsigned)bufLen);
+      }
+    }
+    else
+    {
+      Serial.println("No /config.ini on SPIFFS; LittleFS will start empty");
+    }
+    SPIFFS.end();
+  }
+  else
+  {
+    Serial.println("SPIFFS also unmountable; formatting LittleFS fresh");
+  }
+
+  if (!LittleFS.format())
+  {
+    Serial.println("LittleFS.format() failed");
+    return false;
+  }
+  if (!LittleFS.begin())
+  {
+    Serial.println("LittleFS.begin() after format failed");
+    return false;
+  }
+
+  if (haveConfig)
+  {
+    File out = LittleFS.open(configPath, "w");
+    if (!out)
+    {
+      Serial.println("Could not open /config.ini for write on LittleFS");
+      return true;
+    }
+    out.write((const uint8_t *)buffer, bufLen);
+    out.close();
+    Serial.println("Wrote config.ini to LittleFS");
+  }
+
+  return true;
+}
+```
+
+- [ ] **Step 2: Build to verify**
+
+Run:
+```
+cd RX && pio run -e esp12e
+```
+Expected: build SUCCESS. `defined but not used` warnings on both helpers are still acceptable.
+
+- [ ] **Step 3: Commit**
+
+```
+git add RX/src/main.cpp
+git commit -m "feat(rx): add one-shot SPIFFS to LittleFS migration helper"
+```
+
+---
+
+### Task 3: Switch to LittleFS at the call sites and update `platformio.ini`
+
+This task is atomic — call-site change, include cleanup, and dependency removal in one commit, because each piece breaks the build without the others.
+
+**Files:**
+- Modify: `RX/src/main.cpp` (CONFIGFILE region in `setup()`, plus the `#include <SPIFFSIniFile.h>` line)
+- Modify: `RX/platformio.ini` (lib_deps, board_build.filesystem)
+
+- [ ] **Step 1: Remove the `SPIFFSIniFile` include**
+
+In `RX/src/main.cpp`, delete the line:
+
+```cpp
+#include <SPIFFSIniFile.h>
+```
+
+The include block should now end with `#include <LittleFS.h>` followed by `#include "prototypes.h"`.
+
+- [ ] **Step 2: Replace the CONFIGFILE block in `setup()`**
+
+In `RX/src/main.cpp`, find the existing block between `#pragma region CONFIGFILE` and the `ini.close();` line (currently lines 83–130 inclusive). Replace the **entire** block — from `#pragma region CONFIGFILE` through `ini.close();` — with:
+
+```cpp
+#pragma region CONFIGFILE
+
+  const char *filename = "/config.ini";
+
+  if (!mountFsWithMigration(filename))
+  {
+    Serial.println("Filesystem mount failed");
+    ledMode = -2;
+  }
+  else
+  {
+    int drumType = 0;
+    if (!readConfig(filename, numLeds, drumType))
+    {
+      Serial.print("Config file ");
+      Serial.print(filename);
+      Serial.println(" not found; using defaults");
+    }
+  }
+
+#pragma endregion CONFIGFILE
+```
+
+Notes:
+- The local `buffer[bufferLen]` from the old block is gone — the new parser owns its own state internally.
+- `drumType` is still declared but its value is only used for the log line emitted by `readConfig`; this matches existing behavior (the original code reads it but never uses it after).
+- The "got numLeds" / "got drum type" log lines that previously lived in `setup()` now live inside `readConfig` (so they only print when the key is actually present, matching the old `ini.getValue()` semantics).
+
+- [ ] **Step 3: Update `RX/platformio.ini`**
+
+Replace the file contents with:
+
+```ini
+; PlatformIO Project Configuration File
+;
+;   Build options: build flags, source filter
+;   Upload options: custom upload port, speed and extra flags
+;   Library options: dependencies, extra library storages
+;   Advanced options: extra scripting
+;
+; Please visit documentation for the other options and examples
+; https://docs.platformio.org/page/projectconf.html
+
+[env:esp12e]
+platform = espressif8266
+board = esp12e
+framework = arduino
+board_build.filesystem = littlefs
+monitor_speed = 115200
+lib_deps = 
+	nrf24/RF24@^1.4.10
+	fastled/FastLED@^3.8.0
+monitor_filters = esp8266_exception_decoder
+```
+
+Changes from the existing file: added the `board_build.filesystem = littlefs` line; removed `yurilopes/SPIFFSIniFile@^1.0.0` from `lib_deps`.
+
+- [ ] **Step 4: Build to verify**
+
+Run:
+```
+cd RX && pio run -e esp12e
+```
+Expected: build SUCCESS, with no `defined but not used` warnings (both helpers are now called from `setup()`).
+
+If the build fails complaining about `SPIFFSIniFile.h not found` after `pio` re-resolves deps, run:
+
+```
+cd RX && pio run -e esp12e -t clean && pio run -e esp12e
+```
+
+If it fails complaining about `LittleFS.h`, the ESP8266 core is too old. Check `pio platform show espressif8266 | grep version` — needs core 3.0.0+. Report this to the user rather than attempting a fix.
+
+- [ ] **Step 5: Commit**
+
+```
+git add RX/src/main.cpp RX/platformio.ini
+git commit -m "feat(rx): switch from SPIFFS to LittleFS with first-boot migration"
+```
+
+---
+
+### Task 4: Final verification and handoff notes
+
+- [ ] **Step 1: Confirm the working tree is clean and the build is still green**
+
+Run:
+```
+git status
+cd RX && pio run -e esp12e
+```
+Expected: `git status` shows no uncommitted changes (other than build artifacts); build succeeds.
+
+- [ ] **Step 2: Inspect the final `main.cpp` against the spec**
+
+Open `RX/src/main.cpp` and confirm:
+- No remaining references to `SPIFFSIniFile`, `SPIFFSIniFile.h`, or `ini.` (the old IniFile object).
+- `SPIFFS` is referenced **only** inside `mountFsWithMigration` (the one-shot migration path).
+- `LittleFS` is referenced in `readConfig` and `mountFsWithMigration`.
+- The error path still sets `ledMode = -2` on filesystem failure (preserves the existing DarkMagenta error indicator).
+
+Run a quick grep to verify:
+```
+grep -nE 'SPIFFS|LittleFS|ini\.' RX/src/main.cpp
+```
+
+Expected matches:
+- `SPIFFS` only inside `mountFsWithMigration`
+- `LittleFS` in includes, `readConfig`, and `mountFsWithMigration`
+- No `ini.` matches
+
+- [ ] **Step 3: Write a brief handoff summary for the user**
+
+Report to the user, in the final response:
+
+1. Branch state: commits added on `claude/jolly-dijkstra-fbda9d`.
+2. Build: `pio run -e esp12e` passes from `RX/`.
+3. **What the user must verify on hardware (cannot be done from here):**
+   - Flash one drum that has an existing SPIFFS `/config.ini`. On first boot, the serial monitor should print `LittleFS not present; attempting SPIFFS migration` followed by `Read N bytes of config from SPIFFS` and `Wrote config.ini to LittleFS`. The drum should then come up with its previous `numLeds` / `drumType` values logged.
+   - Reset the same drum. On second boot, the migration messages should be absent — `LittleFS.begin()` succeeds on the first try, and only the `Got numLeds from config` / `Got drum type from config` lines appear.
+   - (Optional) Flash a blank ESP12E. It should fall through to defaults (no `Got numLeds` line) and run without an error LED.
+4. The SPIFFS migration code is intentionally retained as a safety net. Once all deployed drums have booted on this firmware at least once, a follow-up change can strip `SPIFFS.begin()` / `SPIFFS.open()` / etc. from `mountFsWithMigration`.
+
+---
+
+## Self-Review
+
+Spec coverage check (each spec section → task):
+- platformio.ini changes → Task 3, Step 3 ✓
+- First-boot migration flow → Task 2 (helper) + Task 3 (call site) ✓
+- 1024-byte buffer with overflow warning → Task 2, Step 1 (`BUF_SZ = 1024`, `if (f.available())` warning) ✓
+- Tiny custom INI parser (signature: `readConfig(const char*, int&, int&)`) → Task 1, Step 3 ✓
+- Unknown keys silently ignored → Task 1, Step 3 (no else branch) ✓
+- Defaults when file missing → Task 3, Step 2 (only the "not found" log; `numLeds` / `drumType` keep their initial values) ✓
+- `ledMode = -2` on filesystem failure → Task 3, Step 2 ✓
+- Files touched: `RX/platformio.ini`, `RX/src/main.cpp` only → Tasks 1–3 ✓
+- Verification: `pio run -e esp12e` builds → Task 4, Step 1 ✓
+- Hardware verification documented for user → Task 4, Step 3 ✓
+
+No spec section is unaccounted for. No placeholder phrases. Function signatures consistent across tasks (`readConfig`, `mountFsWithMigration`, `numLeds`, `drumType`).

--- a/docs/superpowers/specs/2026-05-17-rx-littlefs-migration-design.md
+++ b/docs/superpowers/specs/2026-05-17-rx-littlefs-migration-design.md
@@ -1,0 +1,119 @@
+# RX: SPIFFS → LittleFS Migration
+
+**Status:** Approved
+**Date:** 2026-05-17
+**Scope:** `RX/` firmware only (ESP8266 / ESP12E). TX is already on LittleFS.
+
+## Goal
+
+Move the RX firmware off SPIFFS (deprecated in the ESP8266 Arduino core) onto LittleFS, while preserving the per-unit `/config.ini` already stored on flash for each deployed drum. The user must not have to re-create or re-upload config files per unit.
+
+## Constraints
+
+- SPIFFS and LittleFS occupy the same flash region but use incompatible on-disk formats. A LittleFS mount on a SPIFFS-formatted area fails, and formatting LittleFS would wipe the existing config. Migration must read SPIFFS data *before* LittleFS formats.
+- `yurilopes/SPIFFSIniFile` is hard-coded to SPIFFS and must be removed.
+- `stevemarple/IniFile` (the upstream) is hard-coded to SD / SdFat and is not a drop-in replacement.
+- Each deployed drum has a distinct `/config.ini` (different `[leds] count` and `[drum] type` values per drum).
+
+## Approach
+
+Three discrete pieces, in `RX/` only.
+
+### 1. `platformio.ini`
+
+Add `board_build.filesystem = littlefs`. Remove the `yurilopes/SPIFFSIniFile` dependency. No other changes.
+
+```ini
+[env:esp12e]
+platform = espressif8266
+board = esp12e
+framework = arduino
+board_build.filesystem = littlefs
+monitor_speed = 115200
+lib_deps =
+    nrf24/RF24@^1.4.10
+    fastled/FastLED@^3.8.0
+monitor_filters = esp8266_exception_decoder
+```
+
+### 2. First-boot migration
+
+Runs in `setup()` before any config reading. Pseudocode:
+
+```
+if LittleFS.begin():
+    // already migrated (or first flash with no prior SPIFFS data)
+    proceed
+else:
+    buffer = empty
+    if SPIFFS.begin():
+        if SPIFFS.exists("/config.ini"):
+            buffer = read entire /config.ini into RAM
+        SPIFFS.end()
+    LittleFS.format()
+    if not LittleFS.begin():
+        ledMode = -2  // file-failure error state
+        // fall through; defaults will be used for numLeds / drumType
+    else if buffer not empty:
+        write buffer to /config.ini on LittleFS
+```
+
+Properties:
+- Idempotent: after a successful migration, subsequent boots take the first branch and never touch SPIFFS.
+- Self-healing: a unit that was never flashed with the new firmware before will still boot — it just starts with an empty filesystem and uses code defaults.
+- Bounded RAM: the config file is tiny (<1 KB in practice). Use a fixed 512-byte buffer; abort migration with an error if larger.
+
+### 3. Tiny custom INI parser
+
+Replaces all `SPIFFSIniFile` call sites. Implemented as a single function in `main.cpp`:
+
+```cpp
+bool readConfig(const char* path, int& numLeds, int& drumType);
+```
+
+Behavior:
+- Opens `path` on `LittleFS`.
+- Single-pass line-oriented scan.
+- Trims whitespace; skips blank lines and lines beginning with `;` or `#`.
+- Tracks `[section]` headers.
+- For each `key = value` line, matches against the known set:
+  - `[leds] count` → writes to `numLeds`
+  - `[drum] type` → writes to `drumType`
+- Unknown keys/sections are silently ignored (forward-compatible with future config additions).
+- Returns `true` if the file was opened (regardless of which keys were present); `false` if the file is missing.
+
+Defaults if the file is missing or a key is absent: the existing initial values in `main.cpp` (`numLeds = MAX_LEDS`, `drumType = 0`). Same behavior as the current SPIFFSIniFile path when a key isn't found.
+
+## Error handling
+
+| Condition | Behavior |
+|---|---|
+| LittleFS mount + format both fail | `ledMode = -2` (existing "file failure" indicator — DarkMagenta error blink) |
+| `/config.ini` missing on LittleFS | Use code defaults, no error LED |
+| Specific key missing in config | Use code defaults for that key, no error LED |
+| SPIFFS-side read fails during migration | Continue with empty buffer; LittleFS still gets formatted; unit uses defaults |
+
+This mirrors the existing tolerance: today the firmware also falls through to defaults if a key is absent.
+
+## Files touched
+
+- `RX/platformio.ini` — `lib_deps` + `board_build.filesystem`
+- `RX/src/main.cpp` — remove `#include <SPIFFSIniFile.h>`, add `#include <LittleFS.h>`, replace the `#pragma region CONFIGFILE` block with the migration + `readConfig()` call, add `readConfig()` definition
+- `RX/data/example.ini` — unchanged (format is compatible)
+
+No changes to `chase.cpp`, `effects.cpp`, `fire.cpp`, `strobes.cpp`, `twinkle.cpp`, or `prototypes.h`.
+
+## Explicitly out of scope
+
+- Adding new config keys
+- Changing the existing error indication scheme
+- Removing the SPIFFS-read migration code (kept as a safety net; can be stripped in a follow-up release after all drums are confirmed migrated)
+- Touching TX-side code
+
+## Verification
+
+- **Build:** PlatformIO `pio run -e esp12e` in `RX/` must succeed with no warnings introduced by the change.
+- **Hardware (user-driven, cannot be done from this environment):**
+  - First boot on a drum with existing SPIFFS config preserves `numLeds` and `drumType` (serial monitor prints expected values).
+  - Second boot uses the LittleFS-only fast path (no SPIFFS mount attempted).
+  - A drum with no prior config falls back to defaults without error LED.

--- a/docs/superpowers/specs/2026-05-17-rx-littlefs-migration-design.md
+++ b/docs/superpowers/specs/2026-05-17-rx-littlefs-migration-design.md
@@ -61,7 +61,7 @@ else:
 Properties:
 - Idempotent: after a successful migration, subsequent boots take the first branch and never touch SPIFFS.
 - Self-healing: a unit that was never flashed with the new firmware before will still boot — it just starts with an empty filesystem and uses code defaults.
-- Bounded RAM: the config file is tiny (<1 KB in practice). Use a fixed 512-byte buffer; abort migration with an error if larger.
+- Bounded RAM: the config file is tiny (the example is ~36 bytes; <1 KB in practice). Use a fixed 1024-byte buffer. If the source file is larger, log a warning over serial, copy the first 1024 bytes anyway, and continue — losing trailing keys is preferable to losing the whole config.
 
 ### 3. Tiny custom INI parser
 


### PR DESCRIPTION
## Summary

Migrates the RX (ESP8266) firmware off the deprecated SPIFFS onto LittleFS, while preserving the per-unit `/config.ini` already stored on each deployed drum. No need to re-flash configs per unit.

## Why

SPIFFS is deprecated in the ESP8266 Arduino core; TX is already on LittleFS. Without a migration step, switching the filesystem flag would wipe every drum's config (SPIFFS and LittleFS share the flash region but have incompatible on-disk formats).

## What's in this PR

Three code commits plus design docs:

1. **`feat(rx): add custom INI parser for LittleFS config`** — Tiny `readConfig` helper that parses the existing `[leds] count` / `[drum] type` keys from LittleFS. Drops the `yurilopes/SPIFFSIniFile` dependency.
2. **`feat(rx): add one-shot SPIFFS to LittleFS migration helper`** — `mountFsWithMigration` reads `/config.ini` from SPIFFS into RAM, formats LittleFS, writes the file back. Idempotent: on subsequent boots `LittleFS.begin()` succeeds first try and the SPIFFS branch is dormant.
3. **`feat(rx): switch from SPIFFS to LittleFS with first-boot migration`** — Atomic switchover: removes `#include <SPIFFSIniFile.h>`, wires the two helpers into `setup()`, adds `board_build.filesystem = littlefs` to `platformio.ini`.

Spec at `docs/superpowers/specs/2026-05-17-rx-littlefs-migration-design.md`. Plan at `docs/superpowers/plans/2026-05-17-rx-littlefs-migration.md`.

## Boot scenarios (traced)

- **Deployed drum, first boot on new firmware** — `LittleFS.begin()` fails → SPIFFS mounted → config read into 1024-byte buffer → `SPIFFS.end()` → `LittleFS.format()` → `LittleFS.begin()` → buffer written back → `readConfig` populates `numLeds` / `drumType`.
- **Same drum, second boot** — `LittleFS.begin()` returns true immediately; no SPIFFS involvement.
- **Fresh ESP12E** — both filesystems empty → `LittleFS.format()` + mount → `readConfig` returns false → log "not found; using defaults" → boots on `MAX_LEDS = 104`, no error LED.

## Build

`pio run -e esp12e` — SUCCESS. RAM 37.0%, Flash 33.0%. No warnings.

## Test plan

Hardware verification must be done by the maintainer — cannot be done from CI / this environment. **Flash one drum first; do NOT batch-flash the fleet until confirmed.**

- [ ] Flash an existing drum with a known `[leds] count` and `[drum] type`. First-boot serial output shows `LittleFS not present; attempting SPIFFS migration`, `Read N bytes of config from SPIFFS`, `Wrote config.ini to LittleFS`, followed by the existing `Got numLeds from config: <value>` / `Got drum type from config: <value>` lines with the original values.
- [ ] Power-cycle the same drum. Second-boot serial output skips the migration messages; only the `Got numLeds` / `Got drum type` lines appear.
- [ ] Flash a fresh / wiped ESP12E. Boots on defaults (104 LEDs) with no error LED and no `Got numLeds` line.

## Known follow-ups (out of scope)

- **SPIFFS-removal cleanup** — The SPIFFS read branch in `mountFsWithMigration` is intentionally kept as a safety net. Strip it in a separate PR once every deployed drum is confirmed migrated (~30-line deletion).
- **Format-success-but-begin-fail edge case** — If `LittleFS.format()` succeeds but the immediate `LittleFS.begin()` afterwards fails, the buffered config is lost with the stack frame. Cross-branch reviewer flagged this; mitigation is to dump the buffer to serial in that branch as a paper trail. Not addressed here because the scenario requires healthy flash that formats but won't mount — effectively a hardware-fault-only case. Happy to add the serial dump as a follow-up if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)