### PR TITLE
Remove one-shot SPIFFS migration code path (RX cleanup)

### DIFF
--- a/RX/src/main.cpp
+++ b/RX/src/main.cpp
@@ -104,53 +104,14 @@ static bool readConfig(const char *path, int &numLeds, int &drumType)
   return true;
 }
 
-// One-time migration: if LittleFS isn't mounted (the flash region is
-// still SPIFFS-formatted), read /config.ini from SPIFFS into RAM,
-// format LittleFS, and write the file back. Idempotent on subsequent
-// boots — LittleFS.begin() succeeds first try and the SPIFFS branch
-// never runs. Returns true if LittleFS is mounted on exit.
-static bool mountFsWithMigration(const char *configPath)
+// Mount LittleFS; format and retry on failure. Returns true on success.
+static bool mountFs()
 {
   if (LittleFS.begin())
   {
     return true;
   }
-
-  Serial.println("LittleFS not present; attempting SPIFFS migration");
-
-  const size_t BUF_SZ = 1024;
-  char buffer[BUF_SZ];
-  size_t bufLen = 0;
-  bool haveConfig = false;
-
-  if (SPIFFS.begin())
-  {
-    if (SPIFFS.exists(configPath))
-    {
-      File f = SPIFFS.open(configPath, "r");
-      if (f)
-      {
-        bufLen = f.readBytes(buffer, BUF_SZ);
-        if (f.available())
-        {
-          Serial.println("WARN: config.ini larger than 1024 bytes; trailing data lost");
-        }
-        f.close();
-        haveConfig = bufLen > 0;
-        Serial.printf("Read %u bytes of config from SPIFFS\n", (unsigned)bufLen);
-      }
-    }
-    else
-    {
-      Serial.println("No /config.ini on SPIFFS; LittleFS will start empty");
-    }
-    SPIFFS.end();
-  }
-  else
-  {
-    Serial.println("SPIFFS also unmountable; formatting LittleFS fresh");
-  }
-
+  Serial.println("LittleFS.begin() failed; formatting");
   if (!LittleFS.format())
   {
     Serial.println("LittleFS.format() failed");
@@ -161,20 +122,6 @@ static bool mountFsWithMigration(const char *configPath)
     Serial.println("LittleFS.begin() after format failed");
     return false;
   }
-
-  if (haveConfig)
-  {
-    File out = LittleFS.open(configPath, "w");
-    if (!out)
-    {
-      Serial.println("Could not open /config.ini for write on LittleFS");
-      return true;
-    }
-    out.write((const uint8_t *)buffer, bufLen);
-    out.close();
-    Serial.println("Wrote config.ini to LittleFS");
-  }
-
   return true;
 }
 
@@ -217,7 +164,7 @@ void setup()
 
   const char *filename = "/config.ini";
 
-  if (!mountFsWithMigration(filename))
+  if (!mountFs())
   {
     Serial.println("Filesystem mount failed");
     ledMode = -2;


### PR DESCRIPTION
## Summary

Removes the SPIFFS read fallback inside `mountFsWithMigration`. Renames the helper to `mountFs` and drops the now-unused `configPath` parameter. After this lands, the RX firmware has zero SPIFFS references.

**Stacked on [#10](https://github.com/PhilDye/Drum-Lights/pull/10).** Do not merge this until every deployed drum has been booted at least once on the firmware from #10 — the SPIFFS branch is what carries each drum's existing config across the format. Removing it before a unit migrates means that unit boots fresh on defaults and loses its config.

GitHub will auto-retarget this PR to `main` once #10 merges.

## Why

The migration helper added in #10 was always intended as a one-time bridge. Keeping it indefinitely costs ~30 KB of flash and pulls a deprecated library into the build for no functional reason once all drums are over.

## Changes

- `mountFsWithMigration(const char *configPath)` → `mountFs()`. Now just: try `LittleFS.begin()`, format on failure, retry.
- Updated the single call site in `setup()`.
- All SPIFFS references in `RX/src/main.cpp` are gone.

## Build

`pio run -e esp12e` — SUCCESS.

| | Before (#10) | After |
| --- | --- | --- |
| RAM | 37.0% | 36.6% |
| Flash | 33.0% | 30.1% |

~30 KB of flash recovered, ~60 lines removed.

## Test plan

- [ ] Confirm every drum in the fleet has booted at least once on #10's firmware (check serial logs or just confirm each drum is operating with its expected config). **Do not merge until this is true.**
- [ ] After merge, flash one drum with this build. Should boot normally and read config from LittleFS (no migration messages).
- [ ] Flash a fresh / wiped ESP12E. Should hit `LittleFS.begin() failed; formatting`, format, mount, and boot on defaults.

🤖 Generated with [Claude Code](https://claude.com/claude-code)